### PR TITLE
Use MutationObserver API to mount components to dynamically-created DOM elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@moltin/request": "2.0.0",
     "algolia-places-react": "1.4.1",
+    "arrive": "2.4.1",
     "easy-peasy": "2.1.6",
     "final-form": "4.12.0",
     "react": "16.8.6",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { MoltinClient } from '@moltin/request'
 import { createStore, StoreProvider } from 'easy-peasy'
 import { ThemeProvider } from 'styled-components'
+import 'arrive';
 
 import model from './model'
 
@@ -55,8 +56,10 @@ function init(document) {
     }
   })
 
-  buttons.forEach(el =>
-    ReactDOM.render(
+  document.arrive(
+    ".moltin-buy-button",
+    { existing: true },
+    (el) => ReactDOM.render(
       <StoreProvider store={store}>
         <ThemeProvider theme={theme}>
           <BuyButton {...el.dataset} />
@@ -64,10 +67,12 @@ function init(document) {
       </StoreProvider>,
       el
     )
-  )
+  );
 
-  cartBtns.forEach(el => {
-    ReactDOM.render(
+  document.arrive(
+    ".moltin-cart-button",
+    { existing: true },
+    (el) => ReactDOM.render(
       <StoreProvider store={store}>
         <ThemeProvider theme={theme}>
           <CartButton {...el.dataset} />
@@ -75,10 +80,12 @@ function init(document) {
       </StoreProvider>,
       el
     )
-  })
+  );
 
-  loginBtns.forEach(el => {
-    ReactDOM.render(
+  document.arrive(
+    ".moltin-login-button",
+    { existing: true },
+    (el) => ReactDOM.render(
       <StoreProvider store={store}>
         <ThemeProvider theme={theme}>
           <LoginButton {...el.dataset} />
@@ -86,7 +93,7 @@ function init(document) {
       </StoreProvider>,
       el
     )
-  })
+  );
 
   ReactDOM.render(
     <StoreProvider store={store}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,6 +1201,11 @@ arrify@^1.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
+arrive@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/arrive/-/arrive-2.4.1.tgz#564c87f20bc09b80de781124d9431695004b8020"
+  integrity sha1-VkyH8gvAm4DeeBEk2UMWlQBLgCA=
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"


### PR DESCRIPTION
Current Behaviour:
* When elements with the appropriate [class and data attributes](https://github.com/moltin/shopkit#step-4) are added to the page dynamically, _after_ the Shopkit script has finished loading, they do not function.
* This is especially apparent on SPAs or PWAs, where navigation occurs via the HTML5 History API, and pages are rendered dynamically via a front end framework.

Expected Behaviour:
* If an eligible element is dynamically added to the page after the Shopkit script has finished loading, they should function as expected, as if they were already on the page at load time.

Proposed Solution in this Pull Request:
* Utilize the [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to listen to the DOM tree efficiently for the addition of elements that match the required criteria to display Shopkit buttons.
* Employed the use of the [`arrive`](https://www.npmjs.com/package/arrive) library, which is a zero-dependency wrapper to the MutationObserver API.
* Modified the `init()` function in `src/index.js` to utilize arrive.

Alternate Solutions:
* Use MutationObserver API directly.
* Provide `window` callbacks to invoke the component mounting manually.